### PR TITLE
Fix for CMake 3.28 Compilation Error with MinGWCross.cmake

### DIFF
--- a/CMakeLists copy.txt
+++ b/CMakeLists copy.txt
@@ -30,6 +30,7 @@ set(VERSION_ALTER "0")
 set(VERSION_BUILD "0")
 set(PACKAGE_NAME "com.borealis.demo")
 set(PSN_TITLE_ID  "MLIGHPLUS")
+
 set(PSN_VERSION  "01.00")
 set(PROJECT_AUTHOR "borealis")
 set(PROJECT_ICON ${CMAKE_CURRENT_SOURCE_DIR}/resources/img/demo_icon.jpg)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,100 @@
-![borealis logo](https://github.com/natinusala/borealis/blob/main/resources/img/borealis_96.png?raw=true)
-# borealis_template
+![VITA-MOONLIGH-PLUS Logo](resources/img/demo_icon.jpg)
 
-This is a template repository for Borealis apps. It contains the necessary files to get you started with your own Borealis app.
+# VITA-MOONLIGH-PLUS
 
-Check Borealis' [Wiki](https://github.com/xfangfang/borealis/wiki) for more information.
+Cliente Moonlight para PlayStation Vita que permite la transmisión de juegos desde tu PC a tu consola portátil.
+
+## 🚀 Características
+
+- Interfaz de usuario optimizada para pantalla táctil y controles de la PS Vita
+- Soporte para transmisión de juegos en 720p
+- Baja latencia para una experiencia de juego fluida
+- Integración con Moonlight Game Streaming
+- Interfaz basada en Borealis, un framework de interfaz de usuario moderno
+
+## 📦 Requisitos
+
+- PlayStation Vita con firmware 3.60 o superior
+- Custom Firmware instalado (H-encore, Henkaku, etc.)
+- Conexión de red estable (se recomienda 5GHz WiFi)
+- PC con GPU compatible con NVIDIA GameStream
+- Aplicación Moonlight instalada en el PC host
+
+## 🛠️ Instalación
+
+1. Asegúrate de tener instalado el Vitashell en tu PS Vita
+2. Copia el archivo `borealis_demo.vpk` a tu PS Vita
+3. Instálalo usando Vitashell
+4. Ejecuta la aplicación desde el LiveArea
+
+## 🔧 Compilación
+
+### Requisitos previos
+
+- **Docker**
+  - Versión 20.10 o superior
+  - Requiere permisos de superusuario (sudo) o pertenecer al grupo 'docker'
+  - Instalación:
+    - [Guía de instalación para Linux](https://docs.docker.com/engine/install/)
+    - [Guía de instalación para Windows](https://docs.docker.com/desktop/windows/install/)
+    - [Guía de instalación para macOS](https://docs.docker.com/desktop/mac/install/)
+
+- **Git**
+  - Última versión estable recomendada
+  - [Descargar Git](https://git-scm.com/downloads)
+
+### Pasos para compilar
+
+1. Clona el repositorio:
+   ```bash
+   git clone https://github.com/AorsiniYT/VITA-MOONLIGH-PLUS.git -b vita
+   cd VITA-MOONLIGH-PLUS
+   ```
+
+2. Ejecuta el script de compilación:
+   ```bash
+   chmod +x makerun
+   ./makerun
+   ```
+
+3. Sigue las instrucciones en pantalla para instalar y ejecutar la aplicación
+
+## 🎮 Uso
+
+1. Asegúrate de que tu PC esté encendida y con Moonlight configurado
+2. Inicia la aplicación en tu PS Vita
+3. Selecciona tu PC de la lista de dispositivos disponibles
+4. ¡Disfruta de la transmisión de juegos!
+
+## 📚 Documentación Adicional
+
+Para más información sobre el desarrollo para PS Vita con Borealis, consulta:
+
+- [Guía de Borealis para PS Vita](https://github.com/xfangfang/borealis/wiki/PS-Vita) - Instrucciones detalladas de configuración y desarrollo
+- [Documentación avanzada de Borealis](https://gist.github.com/xfangfang/305da139721ad4e96d7a9d9a1a550a9d) - Información técnica detallada sobre el framework
+
+## 📝 Notas
+
+- Para obtener el mejor rendimiento, se recomienda una conexión de red cableada en el PC
+- Ajusta la configuración de calidad en la aplicación según tu conexión
+- Algunos juegos pueden requerir configuración adicional en el PC host
+
+## 🤝 Contribución
+
+Las contribuciones son bienvenidas. Por favor, lee las pautas de contribución antes de enviar cambios.
+
+## 📄 Licencia
+
+Este proyecto está bajo la Licencia Apache 2.0. Ver el archivo [LICENSE](LICENSE) para más detalles.
+
+## 🙏 Créditos
+
+Este proyecto utiliza los siguientes proyectos de código abierto:
+
+- [Borealis](https://github.com/xfangfang/borealis) - Biblioteca de interfaz de usuario para aplicaciones Nintendo Switch, PS4, PSVita y más.
+- [VitaSDK](https://github.com/vitasdk/vdpm) - Kit de desarrollo de software para PlayStation Vita.
+- [PVR_PSP2](https://github.com/GrapheneCt/PVR_PSP2) - Módulos PVR para PlayStation Vita.
+
+---
+
+Desarrollado con ❤️ para la comunidad de PS Vita

--- a/install_psv2
+++ b/install_psv2
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+# Instala unzip si no está presente
+sudo apt update
+sudo apt install -y unzip wget
+
+pvr_psp2_version=3.9
+
+# Crea directorios temporales
+mkdir -p /tmp/vita/include
+mkdir -p /tmp/vita/lib
+mkdir -p /tmp/vita/share/sdl2/suprx
+
+# Descarga e instala los headers de PVR_PSP2
+wget -O /tmp/PVR_PSP2.zip "https://github.com/GrapheneCt/PVR_PSP2/archive/refs/tags/v${pvr_psp2_version}.zip"
+unzip /tmp/PVR_PSP2.zip -d /tmp
+cp -r /tmp/PVR_PSP2-${pvr_psp2_version}/include/* /tmp/vita/include
+rm /tmp/PVR_PSP2.zip
+rm -rf /tmp/PVR_PSP2-${pvr_psp2_version}
+
+# Corrige el include guard de khrplatform.h
+sed -i -e 's/__drvkhrplatform_h_/__khrplatform_h_/' /tmp/vita/include/KHR/khrplatform.h
+
+# Descarga e instala las librerías stub
+wget -O /tmp/vitasdk_stubs.zip "https://github.com/GrapheneCt/PVR_PSP2/releases/download/v${pvr_psp2_version}/vitasdk_stubs.zip"
+unzip /tmp/vitasdk_stubs.zip -d /tmp/pvr_psp2_stubs
+find /tmp/pvr_psp2_stubs -type f -name "*.a" -exec cp {} /tmp/vita/lib \;
+rm /tmp/vitasdk_stubs.zip
+rm -rf /tmp/pvr_psp2_stubs
+
+# Descarga e instala los archivos .suprx
+wget -O /tmp/PSVita_Release.zip "https://github.com/GrapheneCt/PVR_PSP2/releases/download/v${pvr_psp2_version}/PSVita_Release.zip"
+unzip /tmp/PSVita_Release.zip -d /tmp/PSVita_Release
+rm -f /tmp/PSVita_Release/libGLESv1_CM.suprx
+rm -f /tmp/PSVita_Release/libpvr2d.suprx
+mv /tmp/PSVita_Release/*.suprx /tmp/vita/share/sdl2/suprx/
+rm -rf /tmp/PSVita_Release.zip
+rm -rf /tmp/PSVita_Release
+
+# Copia los archivos al VITASDK
+if [ -z "$VITASDK" ]; then
+    export VITASDK="/usr/local/vitasdk"
+    echo "La variable de entorno VITASDK no estaba definida. Usando /usr/local/vitasdk"
+fi
+
+cp -rv /tmp/vita/* "$VITASDK/arm-vita-eabi"
+rm -rf /tmp/vita
+
+echo "Instalación de PVR_PSP2 para PSVita completada."

--- a/makerun
+++ b/makerun
@@ -3,85 +3,58 @@
 # Navegar al directorio del proyecto
 cd "$(dirname "$0")"
 
-# Construir con Docker
-if ! docker info > /dev/null 2>&1; then
-    echo "Error: Docker no está corriendo. Inicie el servicio Docker primero."
+echo "[+] Iniciando compilación para PS Vita..."
+
+# Verificar Docker
+if ! docker info &>/dev/null; then
+    echo "Error: Docker no está en ejecución"
     exit 1
 fi
-
-# Asegurar permisos de directorio
-if [ -d "build" ]; then
-    sudo chown -R $USER:$USER build
-fi
-
-# Verificar dependencias externas
-if [ ! -d "library/borealis" ]; then
-    echo "Error: Falta el directorio library/borealis. Clone el repositorio borealis primero."
-    exit 1
-fi
-
-#!/bin/bash
 
 # Configuración
-VITA_IP="192.168.0.193"
-VITA_PORT="1337"
-VITA_CONTROL_PORT="1338"
-VPK_NAME="build/borealis_demo.vpk"
-VITASHELL_ID="VITASHELL"
-TARGET_APP_ID="MLIGHPLUS"
+VITA_IP="192.168.0.193"  # Cambia esto por la IP de tu PS Vita
+VITA_PORT=1337
+VITA_CONTROL_PORT=1338
+VPK_PATH="build/borealis_demo.vpk"
 
-# Función para enviar archivo por FTP
-send_ftp() {
-    echo "Enviando $1 a $2..."
-    curl --ftp-method nocwd -T "$1" "ftp://${VITA_IP}:${VITA_PORT}/$2"
-}
-
-# Función para enviar comando de control
-send_control() {
-    echo "Ejecutando: $1"
-    echo "$1" | nc "$VITA_IP" "$VITA_CONTROL_PORT"
-}
-
-# Construir con Docker
-echo "Construyendo el proyecto..."
-sudo docker run --rm -v $(pwd):/src/ xfangfang/vitasdk_sdl2_gles2:latest \
-  "cd /src && \
-   cmake -B build -G Ninja -DPLATFORM_PSV=ON -DUSE_SYSTEM_SDL2=ON -DCMAKE_BUILD_TYPE=Release && \
+# Compilar con Docker
+echo "[+] Compilando proyecto..."
+mkdir -p build
+docker run --rm -v "$(pwd)":/src/ xfangfang/vitasdk_sdl2_gles2:latest \
+  "cmake -B build -G Ninja -DPLATFORM_PSV=ON -DUSE_SYSTEM_SDL2=ON -DCMAKE_BUILD_TYPE=Release && \
    cmake --build build"
 
-# Verificar generación de VPK
-if [ ! -f "$VPK_NAME" ]; then
-    echo "Error: No se generó el archivo VPK. Archivos en el directorio build:"
+# Verificar si se generó el VPK
+if [ ! -f "$VPK_PATH" ]; then
+    echo "[!] Error: No se generó el VPK"
     ls -la build/
     exit 1
 fi
 
-echo -e "\n¡Archivo VPK generado correctamente!"
-ls -lh "$VPK_NAME"
+VPK_SIZE=$(du -h "$VPK_PATH" | cut -f1)
+echo -e "\n[+] Compilación exitosa! VPK: $VPK_PATH ($VPK_SIZE)"
 
-# Enviar VPK a la PS Vita
-echo -e "\nEnviando VPK a la PS Vita..."
-send_ftp "$VPK_NAME" "ux0:/ABM/"
+# Enviar a la PS Vita
+echo -e "\n[+] Enviando a la PS Vita..."
+curl --ftp-method nocwd -T "$VPK_PATH" "ftp://${VITA_IP}:${VITA_PORT}/ux0:/ABM/"
 
-# Abrir VitaShell
-echo -e "\nAbriendo VitaShell..."
-send_control "launch $VITASHELL_ID"
+echo -e "\n[+] Abriendo VitaShell..."
+echo "launch VITASHELL" | nc "$VITA_IP" "$VITA_CONTROL_PORT"
 
 echo -e "\n==========================================="
-echo "Por favor instala el VPK en VitaShell:"
-echo "1. Navega a ux0:/ABM/"
-echo "2. Selecciona $(basename "$VPK_NAME") y presiona X"
-echo "3. Elige 'Instalar' y confirma"
-echo "4. Presiona O para volver al livearea"
-echo "5. Presiona cualquier tecla aquí cuando la instalación esté completa"
+echo "Instrucciones:"
+echo "1. Ve a ux0:/ABM/ en VitaShell"
+echo "2. Instala $(basename "$VPK_PATH")"
+echo "3. Presiona O para volver al LiveArea"
+echo "4. Presiona ENTER aquí para iniciar la aplicación"
 echo "==========================================="
-read -n 1 -s -r -p ""
 
-# Iniciar la aplicación instalada
-echo -e "\nIniciando $TARGET_APP_ID..."
-send_control "launch $TARGET_APP_ID"
+# Esperar a que el usuario termine de instalar
+read -p "Presiona ENTER para iniciar la aplicación..."
 
-echo "¡Listo!"
-sudo chown -R $USER:$USER build
+# Iniciar la aplicación automáticamente
+echo -e "\n[+] Iniciando la aplicación (MLIGHPLUS)..."
+echo "launch MLIGHPLUS" | nc "$VITA_IP" "$VITA_CONTROL_PORT"
+echo "¡Aplicación iniciada! (MLIGHPLUS)"
 
-echo "Compilación completada. Archivos generados en el directorio build/"
+echo -e "\nCompilación completada. Archivos generados en el directorio build/"

--- a/makerun
+++ b/makerun
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Navegar al directorio del proyecto
+cd "$(dirname "$0")"
+
+# Construir con Docker
+if ! docker info > /dev/null 2>&1; then
+    echo "Error: Docker no está corriendo. Inicie el servicio Docker primero."
+    exit 1
+fi
+
+# Asegurar permisos de directorio
+if [ -d "build" ]; then
+    sudo chown -R $USER:$USER build
+fi
+
+# Verificar dependencias externas
+if [ ! -d "library/borealis" ]; then
+    echo "Error: Falta el directorio library/borealis. Clone el repositorio borealis primero."
+    exit 1
+fi
+
+#!/bin/bash
+
+# Configuración
+VITA_IP="192.168.0.193"
+VITA_PORT="1337"
+VITA_CONTROL_PORT="1338"
+VPK_NAME="build/borealis_demo.vpk"
+VITASHELL_ID="VITASHELL"
+TARGET_APP_ID="MLIGHPLUS"
+
+# Función para enviar archivo por FTP
+send_ftp() {
+    echo "Enviando $1 a $2..."
+    curl --ftp-method nocwd -T "$1" "ftp://${VITA_IP}:${VITA_PORT}/$2"
+}
+
+# Función para enviar comando de control
+send_control() {
+    echo "Ejecutando: $1"
+    echo "$1" | nc "$VITA_IP" "$VITA_CONTROL_PORT"
+}
+
+# Construir con Docker
+echo "Construyendo el proyecto..."
+sudo docker run --rm -v $(pwd):/src/ xfangfang/vitasdk_sdl2_gles2:latest \
+  "cd /src && \
+   cmake -B build -G Ninja -DPLATFORM_PSV=ON -DUSE_SYSTEM_SDL2=ON -DCMAKE_BUILD_TYPE=Release && \
+   cmake --build build"
+
+# Verificar generación de VPK
+if [ ! -f "$VPK_NAME" ]; then
+    echo "Error: No se generó el archivo VPK. Archivos en el directorio build:"
+    ls -la build/
+    exit 1
+fi
+
+echo -e "\n¡Archivo VPK generado correctamente!"
+ls -lh "$VPK_NAME"
+
+# Enviar VPK a la PS Vita
+echo -e "\nEnviando VPK a la PS Vita..."
+send_ftp "$VPK_NAME" "ux0:/ABM/"
+
+# Abrir VitaShell
+echo -e "\nAbriendo VitaShell..."
+send_control "launch $VITASHELL_ID"
+
+echo -e "\n==========================================="
+echo "Por favor instala el VPK en VitaShell:"
+echo "1. Navega a ux0:/ABM/"
+echo "2. Selecciona $(basename "$VPK_NAME") y presiona X"
+echo "3. Elige 'Instalar' y confirma"
+echo "4. Presiona O para volver al livearea"
+echo "5. Presiona cualquier tecla aquí cuando la instalación esté completa"
+echo "==========================================="
+read -n 1 -s -r -p ""
+
+# Iniciar la aplicación instalada
+echo -e "\nIniciando $TARGET_APP_ID..."
+send_control "launch $TARGET_APP_ID"
+
+echo "¡Listo!"
+sudo chown -R $USER:$USER build
+
+echo "Compilación completada. Archivos generados en el directorio build/"


### PR DESCRIPTION
Hello, when trying to compile with:

cmake -B build_mingw -DPLATFORM_DESKTOP=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="library/cmake/MinGWCross.cmake"

produces an error with the latest version of CMake 3.28, this configuration fixes it.